### PR TITLE
@property compliance.

### DIFF
--- a/terminal.d
+++ b/terminal.d
@@ -271,7 +271,7 @@ struct Terminal {
 					handleTermcapLine(line);
 				}
 			} else {
-				foreach(line; File("/etc/termcap").byLine) {
+				foreach(line; File("/etc/termcap").byLine()) {
 					handleTermcapLine(line);
 				}
 			}
@@ -601,11 +601,11 @@ struct Terminal {
 		}
 	}
 
-	int width() {
+	@property int width() {
 		return getSize()[0];
 	}
 
-	int height() {
+	@property int height() {
 		return getSize()[1];
 	}
 
@@ -1245,7 +1245,7 @@ struct InputEvent {
 
 	@property Type type() { return t; }
 
-	auto get(Type T)() {
+	@property auto get(Type T)() {
 		if(type != T)
 			throw new Exception("Wrong event type");
 		static if(T == Type.CharacterEvent)


### PR DESCRIPTION
Make terminal.d compilable with -property.

Wasn't sure whether InputEvent.get should be a @property, but since its only arguments are compile-time arguments, I decided to make it a @property so that you don't have to keep writing () at the end.
