### PR TITLE
Fixed function which did not exist

### DIFF
--- a/source/consoled.d
+++ b/source/consoled.d
@@ -1180,7 +1180,7 @@ void drawVerticalLine(ConsolePoint pos, int length, char border)
  */
 void writeAt(T)(ConsolePoint point, T data)
 {
-    setConsoleCursor(point.x, point.y);
+    setCursorPos(point.x, point.y);
     write(data);
     stdout.flush();
 }


### PR DESCRIPTION
setConsoleCursor(x,y) is not a function. Changed to setCursorPos(x,y)
Fixes issue #15