### PR TITLE
Cast buffer length argument to uint.

### DIFF
--- a/source/terminal.d
+++ b/source/terminal.d
@@ -1024,7 +1024,8 @@ http://msdn.microsoft.com/en-us/library/windows/desktop/ms683193%28v=vs.85%29.as
 			wstring writeBufferw = to!wstring(writeBuffer);
 			while(writeBufferw.length) {
 				DWORD written;
-				WriteConsoleW(hConsole, writeBufferw.ptr, writeBufferw.length, &written, null);
+				// NOTE: WriteConsoleW expects a uint parameter to be given as length.
+				WriteConsoleW(hConsole, writeBufferw.ptr, cast(uint) writeBufferw.length, &written, null);
 				writeBufferw = writeBufferw[written .. $];
 			}
 


### PR DESCRIPTION
This fixes 64-bit builds on windows, where `writeBufferw.length` is a `ulong`.

Previously,
```
source\terminal.d(1027,18): Error: function core.sys.windows.windows.WriteConsoleW (void* hConsoleOutput, const(void*) lpBuffer, uint nNumberOfCharsToWrite, uint* lpNumberOfCharsWritten, void* lpReserved) is not callable using argument types (void*, immutable(wchar)*, ulong, uint*, typeof(null))
```